### PR TITLE
Add image mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,8 @@ ite8291r3-ctl mode --screen 1000,1000,200,300
 ![screen mode demo](https://i.imgur.com/qYapxwf.gif)
 
 #### image
-You also need to install `Pillow` Python packages. You can install them by installing the utility with `pip install ite8291r3_ctl[mode-image]`.
+You also need to install `Pillow` Python package. You can install them by installing the utility with `pip install ite8291r3_ctl[mode-image]`.
+
 The `image` mode takes an image, downsizes it to 16x6, and lights up the backlight LEDs according to the colors on the image.
 
 *Example:*

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ If you believen your device should be supported, but it is not, please open an i
 #### for the `screen` mode
 * [`python-xlib`](https://pypi.org/project/python-xlib) Python package
 * [`Pillow`](https://pypi.org/project/Pillow) Python package
-
+#### for the `picture` mode
+* [`Pillow`](https://pypi.org/project/Pillow) Python package
 
 # Features
 ## Current
@@ -38,6 +39,7 @@ If you believen your device should be supported, but it is not, please open an i
 * Per-key RGB colors
 * Animations
 * Coloring the keyboard according to what is on screen **[exprimental, Linux+Xorg only]**
+* Coloring the keyboard according to a picture
 * Querying parts of the controller state
 
 ## TO-DO

--- a/README.md
+++ b/README.md
@@ -212,7 +212,9 @@ ite8291r3-ctl palette --random
 
 ___
 ### mode
-**[experimental]** Enables one of the interactive modes. There is only a single mode available at the moment: `screen`, and it only works on Linux, with Xorg. You also need to install `python-xlib` and `Pillow` Python pacakges. You can install them by installing the utility with `pip install ite8291r3_ctl[mode-screen]`.
+**[experimental]** Enables one of the interactive modes.
+#### screen
+Only works on Linux, with Xorg. You also need to install `python-xlib` and `Pillow` Python pacakges. You can install them by installing the utility with `pip install ite8291r3_ctl[mode-screen]`.
 
 The `screen` mode takes a screenshot every 0.2 seconds of your screen, downsizes it to 16x6, and lights up the backlight LEDs according to the colors on the picture. [This video](https://www.youtube.com/watch?v=3VZthcTSBrI) is perfect for trying it out. The colors are not cleared after exiting, so I guess this is also a way to set the desired colors if you don't want to spend time with the more robust way described in the following section.
 
@@ -231,6 +233,14 @@ ite8291r3-ctl mode --screen 1000,1000,200,300
 
 ![screen mode demo](https://i.imgur.com/qYapxwf.gif)
 
+#### image
+You also need to install `Pillow` Python packages. You can install them by installing the utility with `pip install ite8291r3_ctl[mode-image]`.
+The `image` mode takes an image, downsizes it to 16x6, and lights up the backlight LEDs according to the colors on the image.
+
+*Example:*
+```
+ite8291r3-ctl mode --image /path/to/the/image
+```
 ___
 ### anim
 Plays an animation from a file. The name might be a bit misleading, because this is actually the facility of the program that allows you to set the color values on a per key basis. Read the README file in `assets/animatins` to see how animations may be made. It is a bit cumbersome, I am aware, however, a better way has yet to be found. The animation may be read from the standard input, so you can programatically generate it.

--- a/ite8291r3_ctl/__main__.py
+++ b/ite8291r3_ctl/__main__.py
@@ -20,6 +20,22 @@ color_name_to_rgb = {
 	"orange":  (255, 28, 0),
 }
 
+def picture_mode(handle, picture_path=None):
+	import os
+	from PIL import Image
+	if os.path.exists(picture_path) is not True:
+		return
+
+	im = Image.open(picture_path)
+	im = im.resize((16, 6), resample=Image.BOX)
+	handle.enable_user_mode()
+	color_map = {}
+
+	for row in range(6):
+		for col in range(16):
+			color_map[(row, col)] = im.getpixel((col, 5-row))
+	handle.set_key_colors(color_map, enable_user_mode=False)
+
 def screen_mode(handle, offset_x=None, offset_y=None, width=None, height=None):
 	from Xlib import display, X
 	from PIL import Image
@@ -190,6 +206,8 @@ def main():
 				screen_mode(handle, *data)
 			except KeyboardInterrupt:
 				pass
+		elif args.picture is not None:
+			picture_mode(handle, args.picture)
 
 	def handle_anim_args(args):
 		import time
@@ -332,6 +350,7 @@ def main():
 	parser_mode = subparsers.add_parser('mode', help='Enable interactive modes.')
 	group = parser_mode.add_mutually_exclusive_group()
 	group.add_argument('--screen', metavar='offset_x,offset_y,width,height', nargs='?', const='fullscreen', help='Color the keyboard according to what is on the screen in the given region.')
+	group.add_argument('--picture', metavar='picture_path', nargs='?', const='fullscreen', help='Color the keyboard according to a given picture.')
 	parser_mode.set_defaults(func=handle_mode_args)
 
 	parser_anim = subparsers.add_parser('anim', help='Play animation.')

--- a/ite8291r3_ctl/__main__.py
+++ b/ite8291r3_ctl/__main__.py
@@ -23,7 +23,7 @@ color_name_to_rgb = {
 def image_mode(handle, image_path):
 	from PIL import Image
 
-	im = Image.open(image_path)
+	im = Image.open(image_path[0].name)
 	im = im.resize((16, 6), resample=Image.BOX)
 	handle.enable_user_mode()
 	color_map = {}

--- a/ite8291r3_ctl/__main__.py
+++ b/ite8291r3_ctl/__main__.py
@@ -20,13 +20,13 @@ color_name_to_rgb = {
 	"orange":  (255, 28, 0),
 }
 
-def picture_mode(handle, picture_path=None):
+def image_mode(handle, image_path=None):
 	import os
 	from PIL import Image
-	if os.path.exists(picture_path) is not True:
+	if os.path.exists(image_path) is not True:
 		return
 
-	im = Image.open(picture_path)
+	im = Image.open(image_path)
 	im = im.resize((16, 6), resample=Image.BOX)
 	handle.enable_user_mode()
 	color_map = {}
@@ -206,8 +206,8 @@ def main():
 				screen_mode(handle, *data)
 			except KeyboardInterrupt:
 				pass
-		elif args.picture is not None:
-			picture_mode(handle, args.picture)
+		elif args.image is not None:
+			image_mode(handle, args.image)
 
 	def handle_anim_args(args):
 		import time
@@ -350,7 +350,7 @@ def main():
 	parser_mode = subparsers.add_parser('mode', help='Enable interactive modes.')
 	group = parser_mode.add_mutually_exclusive_group()
 	group.add_argument('--screen', metavar='offset_x,offset_y,width,height', nargs='?', const='fullscreen', help='Color the keyboard according to what is on the screen in the given region.')
-	group.add_argument('--picture', metavar='picture_path', nargs='?', const='fullscreen', help='Color the keyboard according to a given picture.')
+	group.add_argument('--image', metavar='image_path', nargs='?', const='fullscreen', help='Color the keyboard according to a given image.')
 	parser_mode.set_defaults(func=handle_mode_args)
 
 	parser_anim = subparsers.add_parser('anim', help='Play animation.')

--- a/ite8291r3_ctl/__main__.py
+++ b/ite8291r3_ctl/__main__.py
@@ -20,11 +20,8 @@ color_name_to_rgb = {
 	"orange":  (255, 28, 0),
 }
 
-def image_mode(handle, image_path=None):
-	import os
+def image_mode(handle, image_path):
 	from PIL import Image
-	if os.path.exists(image_path) is not True:
-		return
 
 	im = Image.open(image_path)
 	im = im.resize((16, 6), resample=Image.BOX)
@@ -350,7 +347,7 @@ def main():
 	parser_mode = subparsers.add_parser('mode', help='Enable interactive modes.')
 	group = parser_mode.add_mutually_exclusive_group()
 	group.add_argument('--screen', metavar='offset_x,offset_y,width,height', nargs='?', const='fullscreen', help='Color the keyboard according to what is on the screen in the given region.')
-	group.add_argument('--image', metavar='image_path', nargs='?', const='fullscreen', help='Color the keyboard according to a given image.')
+	group.add_argument('--image', metavar='path', nargs='1', type=argparse.FileType('rb'), help='Color the keyboard according to a given image.')
 	parser_mode.set_defaults(func=handle_mode_args)
 
 	parser_anim = subparsers.add_parser('anim', help='Play animation.')

--- a/ite8291r3_ctl/__main__.py
+++ b/ite8291r3_ctl/__main__.py
@@ -347,7 +347,7 @@ def main():
 	parser_mode = subparsers.add_parser('mode', help='Enable interactive modes.')
 	group = parser_mode.add_mutually_exclusive_group()
 	group.add_argument('--screen', metavar='offset_x,offset_y,width,height', nargs='?', const='fullscreen', help='Color the keyboard according to what is on the screen in the given region.')
-	group.add_argument('--image', metavar='path', nargs='1', type=argparse.FileType('rb'), help='Color the keyboard according to a given image.')
+	group.add_argument('--image', metavar='path', nargs=1, type=argparse.FileType('rb'), help='Color the keyboard according to a given image.')
 	parser_mode.set_defaults(func=handle_mode_args)
 
 	parser_anim = subparsers.add_parser('anim', help='Play animation.')

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
 	
 	extras_require={
 		'mode-screen': ['python-xlib', 'Pillow'],
+		'mode-picture': ['Pillow'],
 	},
 	
 	project_urls={

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
 	
 	extras_require={
 		'mode-screen': ['python-xlib', 'Pillow'],
-		'mode-picture': ['Pillow'],
+		'mode-image': ['Pillow'],
 	},
 	
 	project_urls={


### PR DESCRIPTION
Largely inspired by the screen mode.
This mode takes a path to an image, downsizes it to 16x6, and lights up the backlight LEDs according to the colors on the image.

*Example:*
```
ite8291r3-ctl mode --image ~/MyImage.png
```