### PR TITLE
Add support for 0x048d:0x600b (Slimbook CREA15-AI9-RTX5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The following devices have been reported to work:
 |----------|-----------|-----------|--------------------------------------|-------------------|
 | 048d     | 6004      | 0.03      | Integrated Technology Express, Inc.  | ITE Device(8291)  |
 | 048d     | 6006      | 0.03      | Integrated Technology Express, Inc.  | ITE Device(8291)  |
+| 048d     | 600b      | 0.03      | Integrated Technology Express, Inc.  | ITE Device(8291)  |
 | 048d     | ce00      | 0.03      | Integrated Technology Express, Inc.  | ITE Device(8291)  |
 
 If you believen your device should be supported, but it is not, please open an issue. You can run `ite8291r3-ctl query --devices` to see the supported devices found in the system. Alternatively, you can use `lsusb -d 048d:`.

--- a/ite8291r3_ctl/ite8291r3.py
+++ b/ite8291r3_ctl/ite8291r3.py
@@ -6,7 +6,7 @@ import usb.core
 import usb.util
 
 VENDOR_ID   = 0x048D
-PRODUCT_IDS = [0x6004, 0x6006, 0xCE00]
+PRODUCT_IDS = [0x6004, 0x6006, 0x600B, 0xCE00]
 REV_NUMBER  = 0x0003 # 0.03
 
 NUM_ROWS = 6


### PR DESCRIPTION
## Description

Add support for the ITE 8291 (rev 0.03) RGB keyboard backlight controller found in the **Slimbook CREA15-AI9-RTX5**.

The device uses the same chip and protocol as the already supported IDs — only the USB product ID differs.

## Device info

```
idVendor:  0x048d  (Integrated Technology Express, Inc.)
idProduct: 0x600b
bcdDevice: 0.03
```

```
$ lsusb -d 048d:600b
Bus 003 Device 003: ID 048d:600b Integrated Technology Express, Inc. ITE Device(8291)
```

## Testing

Tested on Slimbook CREA15-AI9-RTX5 running CachyOS (kernel 7.0.9-1-cachyos). All subcommands work correctly:

- `monocolor`, `brightness`, `off`, `effect`, `query`