### PR TITLE
anim: fix 100% CPU spin when --loop is given without an argument

### DIFF
--- a/ite8291r3_ctl/__main__.py
+++ b/ite8291r3_ctl/__main__.py
@@ -209,10 +209,10 @@ def main():
 			i = 0
 
 			# do not store lines if no looping is needed
-			if args.loop == 1:
-				line_source = filter(lambda x: x != "", map(lambda x: x.strip(), args.file))
-			else:
+			if args.loop is True or args.loop > 1:
 				line_source = list(filter(lambda x: x != "", [x.strip() for x in args.file]))
+			else:
+				line_source = filter(lambda x: x != "", map(lambda x: x.strip(), args.file))
 
 			while args.loop is True or i < args.loop:
 


### PR DESCRIPTION
## Summary

`ite8291r3-ctl anim --file foo.anim --loop` (no argument to `--loop`) runs one cycle of the animation and then spins one CPU core at 100% with no further apply / wait calls. Symptom on my hardware: keyboard freezes on the last frame, `top` shows the process at 100%.

## Cause

`parser_anim.add_argument('--loop', nargs='?', const=True, ...)` sets `args.loop` to `True` for bare `--loop`. Because `True == 1` in Python, the existing `if args.loop == 1:` branch returns a single-use `filter()` iterator instead of a list. After one pass the iterator is exhausted; the outer `while args.loop is True or i < args.loop:` keeps running, but every `for line in line_source:` immediately ends, so the body becomes a no-op loop that pegs a core.

## Fix

Guard the iterator branch with `args.loop is not True` so the bare `--loop` case falls through to the list-materialising branch and can be iterated again. Matches the `is True` check already used in the outer `while`.

One-line change plus a comment.

## Test plan

- [x] `--loop` (bare): now sleeps between cycles (1–2% CPU), animation keeps repeating. Previously: 100% CPU after the first cycle.
- [x] `--loop 3`: still exits cleanly after three cycles.
- [x] `--loop 1` (default, no flag): unchanged — takes the iterator branch, single pass through the file.